### PR TITLE
Add Talker Alias support

### DIFF
--- a/GD-77_new_firmware/firmware/.cproject
+++ b/GD-77_new_firmware/firmware/.cproject
@@ -301,6 +301,12 @@
 							<inputType id="com.crt.advproject.compiler.input.924230645" superClass="com.crt.advproject.compiler.input"/>
 						</tool>
 					</fileInfo>
+					<fileInfo id="com.crt.advproject.config.exe.debug.1021312312.710535914" name="menuDebug.c" rcbsApplicability="disable" resourcePath="source/menu/menuDebug.c" toolsToInvoke="com.crt.advproject.gcc.exe.debug.475830819.1118699335">
+						<tool id="com.crt.advproject.gcc.exe.debug.475830819.1118699335" name="MCU C Compiler" superClass="com.crt.advproject.gcc.exe.debug.475830819">
+							<option id="com.crt.advproject.gcc.exe.debug.option.optimization.level.212594359" name="Optimization Level" superClass="com.crt.advproject.gcc.exe.debug.option.optimization.level" useByScannerDiscovery="false" value="gnu.c.optimization.level.size" valueType="enumerated"/>
+							<inputType id="com.crt.advproject.compiler.input.1610740277" superClass="com.crt.advproject.compiler.input"/>
+						</tool>
+					</fileInfo>
 					<sourceEntries>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH" kind="sourcePath" name="usb"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH" kind="sourcePath" name="startup"/>

--- a/GD-77_new_firmware/firmware/.cproject
+++ b/GD-77_new_firmware/firmware/.cproject
@@ -295,28 +295,10 @@
 							<inputType id="com.crt.advproject.compiler.input.792055670" superClass="com.crt.advproject.compiler.input"/>
 						</tool>
 					</fileInfo>
-					<fileInfo id="com.crt.advproject.config.exe.debug.1021312312.768207144" name="fw_main.c" rcbsApplicability="disable" resourcePath="source/fw_main.c" toolsToInvoke="com.crt.advproject.gcc.exe.debug.475830819.1907863155">
-						<tool id="com.crt.advproject.gcc.exe.debug.475830819.1907863155" name="MCU C Compiler" superClass="com.crt.advproject.gcc.exe.debug.475830819">
-							<option id="com.crt.advproject.gcc.exe.debug.option.optimization.level.1290767502" name="Optimization Level" superClass="com.crt.advproject.gcc.exe.debug.option.optimization.level" useByScannerDiscovery="false" value="gnu.c.optimization.level.none" valueType="enumerated"/>
-							<inputType id="com.crt.advproject.compiler.input.205123457" superClass="com.crt.advproject.compiler.input"/>
-						</tool>
-					</fileInfo>
 					<fileInfo id="com.crt.advproject.config.exe.debug.1021312312.1781669916" name="fw_sound.c" rcbsApplicability="disable" resourcePath="source/functions/fw_sound.c" toolsToInvoke="com.crt.advproject.gcc.exe.debug.475830819.1086827945">
 						<tool id="com.crt.advproject.gcc.exe.debug.475830819.1086827945" name="MCU C Compiler" superClass="com.crt.advproject.gcc.exe.debug.475830819">
-							<option id="com.crt.advproject.gcc.exe.debug.option.optimization.level.1802971681" name="Optimization Level" superClass="com.crt.advproject.gcc.exe.debug.option.optimization.level" useByScannerDiscovery="false" value="gnu.c.optimization.level.none" valueType="enumerated"/>
+							<option id="com.crt.advproject.gcc.exe.debug.option.optimization.level.1802971681" name="Optimization Level" superClass="com.crt.advproject.gcc.exe.debug.option.optimization.level" useByScannerDiscovery="false" value="gnu.c.optimization.level.more" valueType="enumerated"/>
 							<inputType id="com.crt.advproject.compiler.input.924230645" superClass="com.crt.advproject.compiler.input"/>
-						</tool>
-					</fileInfo>
-					<fileInfo id="com.crt.advproject.config.exe.debug.1021312312.333237175" name="menuLastHeard.c" rcbsApplicability="disable" resourcePath="source/menu/menuLastHeard.c" toolsToInvoke="com.crt.advproject.gcc.exe.debug.475830819.1054242714">
-						<tool id="com.crt.advproject.gcc.exe.debug.475830819.1054242714" name="MCU C Compiler" superClass="com.crt.advproject.gcc.exe.debug.475830819">
-							<option id="com.crt.advproject.gcc.exe.debug.option.optimization.level.1767795431" name="Optimization Level" superClass="com.crt.advproject.gcc.exe.debug.option.optimization.level" useByScannerDiscovery="false" value="gnu.c.optimization.level.size" valueType="enumerated"/>
-							<inputType id="com.crt.advproject.compiler.input.1550219936" superClass="com.crt.advproject.compiler.input"/>
-						</tool>
-					</fileInfo>
-					<fileInfo id="com.crt.advproject.config.exe.debug.1021312312.728403387" name="fsl_sai_edma.c" rcbsApplicability="disable" resourcePath="drivers/fsl_sai_edma.c" toolsToInvoke="com.crt.advproject.gcc.exe.debug.475830819.450092831">
-						<tool id="com.crt.advproject.gcc.exe.debug.475830819.450092831" name="MCU C Compiler" superClass="com.crt.advproject.gcc.exe.debug.475830819">
-							<option id="com.crt.advproject.gcc.exe.debug.option.optimization.level.1148975127" name="Optimization Level" superClass="com.crt.advproject.gcc.exe.debug.option.optimization.level" useByScannerDiscovery="false" value="gnu.c.optimization.level.size" valueType="enumerated"/>
-							<inputType id="com.crt.advproject.compiler.input.113318290" superClass="com.crt.advproject.compiler.input"/>
 						</tool>
 					</fileInfo>
 					<sourceEntries>

--- a/GD-77_new_firmware/firmware/.cproject
+++ b/GD-77_new_firmware/firmware/.cproject
@@ -295,6 +295,12 @@
 							<inputType id="com.crt.advproject.compiler.input.792055670" superClass="com.crt.advproject.compiler.input"/>
 						</tool>
 					</fileInfo>
+					<fileInfo id="com.crt.advproject.config.exe.debug.1021312312.333237175" name="menuLastHeard.c" rcbsApplicability="disable" resourcePath="source/menu/menuLastHeard.c" toolsToInvoke="com.crt.advproject.gcc.exe.debug.475830819.1054242714">
+						<tool id="com.crt.advproject.gcc.exe.debug.475830819.1054242714" name="MCU C Compiler" superClass="com.crt.advproject.gcc.exe.debug.475830819">
+							<option id="com.crt.advproject.gcc.exe.debug.option.optimization.level.1767795431" name="Optimization Level" superClass="com.crt.advproject.gcc.exe.debug.option.optimization.level" useByScannerDiscovery="false" value="gnu.c.optimization.level.size" valueType="enumerated"/>
+							<inputType id="com.crt.advproject.compiler.input.1550219936" superClass="com.crt.advproject.compiler.input"/>
+						</tool>
+					</fileInfo>
 					<sourceEntries>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH" kind="sourcePath" name="usb"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH" kind="sourcePath" name="startup"/>

--- a/GD-77_new_firmware/firmware/.cproject
+++ b/GD-77_new_firmware/firmware/.cproject
@@ -301,12 +301,6 @@
 							<inputType id="com.crt.advproject.compiler.input.924230645" superClass="com.crt.advproject.compiler.input"/>
 						</tool>
 					</fileInfo>
-					<fileInfo id="com.crt.advproject.config.exe.debug.1021312312.710535914" name="menuDebug.c" rcbsApplicability="disable" resourcePath="source/menu/menuDebug.c" toolsToInvoke="com.crt.advproject.gcc.exe.debug.475830819.1118699335">
-						<tool id="com.crt.advproject.gcc.exe.debug.475830819.1118699335" name="MCU C Compiler" superClass="com.crt.advproject.gcc.exe.debug.475830819">
-							<option id="com.crt.advproject.gcc.exe.debug.option.optimization.level.212594359" name="Optimization Level" superClass="com.crt.advproject.gcc.exe.debug.option.optimization.level" useByScannerDiscovery="false" value="gnu.c.optimization.level.size" valueType="enumerated"/>
-							<inputType id="com.crt.advproject.compiler.input.1610740277" superClass="com.crt.advproject.compiler.input"/>
-						</tool>
-					</fileInfo>
 					<sourceEntries>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH" kind="sourcePath" name="usb"/>
 						<entry flags="LOCAL|VALUE_WORKSPACE_PATH" kind="sourcePath" name="startup"/>

--- a/GD-77_new_firmware/firmware/.cproject
+++ b/GD-77_new_firmware/firmware/.cproject
@@ -295,10 +295,28 @@
 							<inputType id="com.crt.advproject.compiler.input.792055670" superClass="com.crt.advproject.compiler.input"/>
 						</tool>
 					</fileInfo>
+					<fileInfo id="com.crt.advproject.config.exe.debug.1021312312.768207144" name="fw_main.c" rcbsApplicability="disable" resourcePath="source/fw_main.c" toolsToInvoke="com.crt.advproject.gcc.exe.debug.475830819.1907863155">
+						<tool id="com.crt.advproject.gcc.exe.debug.475830819.1907863155" name="MCU C Compiler" superClass="com.crt.advproject.gcc.exe.debug.475830819">
+							<option id="com.crt.advproject.gcc.exe.debug.option.optimization.level.1290767502" name="Optimization Level" superClass="com.crt.advproject.gcc.exe.debug.option.optimization.level" useByScannerDiscovery="false" value="gnu.c.optimization.level.none" valueType="enumerated"/>
+							<inputType id="com.crt.advproject.compiler.input.205123457" superClass="com.crt.advproject.compiler.input"/>
+						</tool>
+					</fileInfo>
+					<fileInfo id="com.crt.advproject.config.exe.debug.1021312312.1781669916" name="fw_sound.c" rcbsApplicability="disable" resourcePath="source/functions/fw_sound.c" toolsToInvoke="com.crt.advproject.gcc.exe.debug.475830819.1086827945">
+						<tool id="com.crt.advproject.gcc.exe.debug.475830819.1086827945" name="MCU C Compiler" superClass="com.crt.advproject.gcc.exe.debug.475830819">
+							<option id="com.crt.advproject.gcc.exe.debug.option.optimization.level.1802971681" name="Optimization Level" superClass="com.crt.advproject.gcc.exe.debug.option.optimization.level" useByScannerDiscovery="false" value="gnu.c.optimization.level.none" valueType="enumerated"/>
+							<inputType id="com.crt.advproject.compiler.input.924230645" superClass="com.crt.advproject.compiler.input"/>
+						</tool>
+					</fileInfo>
 					<fileInfo id="com.crt.advproject.config.exe.debug.1021312312.333237175" name="menuLastHeard.c" rcbsApplicability="disable" resourcePath="source/menu/menuLastHeard.c" toolsToInvoke="com.crt.advproject.gcc.exe.debug.475830819.1054242714">
 						<tool id="com.crt.advproject.gcc.exe.debug.475830819.1054242714" name="MCU C Compiler" superClass="com.crt.advproject.gcc.exe.debug.475830819">
 							<option id="com.crt.advproject.gcc.exe.debug.option.optimization.level.1767795431" name="Optimization Level" superClass="com.crt.advproject.gcc.exe.debug.option.optimization.level" useByScannerDiscovery="false" value="gnu.c.optimization.level.size" valueType="enumerated"/>
 							<inputType id="com.crt.advproject.compiler.input.1550219936" superClass="com.crt.advproject.compiler.input"/>
+						</tool>
+					</fileInfo>
+					<fileInfo id="com.crt.advproject.config.exe.debug.1021312312.728403387" name="fsl_sai_edma.c" rcbsApplicability="disable" resourcePath="drivers/fsl_sai_edma.c" toolsToInvoke="com.crt.advproject.gcc.exe.debug.475830819.450092831">
+						<tool id="com.crt.advproject.gcc.exe.debug.475830819.450092831" name="MCU C Compiler" superClass="com.crt.advproject.gcc.exe.debug.475830819">
+							<option id="com.crt.advproject.gcc.exe.debug.option.optimization.level.1148975127" name="Optimization Level" superClass="com.crt.advproject.gcc.exe.debug.option.optimization.level" useByScannerDiscovery="false" value="gnu.c.optimization.level.size" valueType="enumerated"/>
+							<inputType id="com.crt.advproject.compiler.input.113318290" superClass="com.crt.advproject.compiler.input"/>
 						</tool>
 					</fileInfo>
 					<sourceEntries>

--- a/GD-77_new_firmware/firmware/include/chips/fw_HR-C6000.h
+++ b/GD-77_new_firmware/firmware/include/chips/fw_HR-C6000.h
@@ -73,9 +73,9 @@ extern int slot_state;
 extern int tick_cnt;
 extern int skip_count;
 
-extern int last_TG;
-extern int last_DMRID;
-extern int qsodata_timer;
+//extern int last_TG;
+//extern int last_DMRID;
+//extern int qsodata_timer;
 
 extern int tx_sequence;
 

--- a/GD-77_new_firmware/firmware/include/functions/fw_calibration.h
+++ b/GD-77_new_firmware/firmware/include/functions/fw_calibration.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2019 Kai Ludwig, DG4KLU
+ * Copyright (C)2019 Roger Clark. VK3KYY / G4KYF
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -23,36 +23,17 @@
  * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#ifndef _FW_MENU_LEGACY_CODEPLUG_UTILS_H_
+#define _FW_MENU_LEGACY_CODEPLUG_UTILS_H_
+#include "fw_common.h"
 
-#ifndef _FW_TRX_H_
-#define _FW_TRX_H_
+typedef struct calibrationStruct
+{
+	int masterOscillator;
+	uint8_t powerLevels[16];
+} calibrationStruct_t;
 
-#include "fw_sound.h"
-#include "fw_i2c.h"
+extern calibrationStruct_t calibrationVHF;
+extern calibrationStruct_t calibrationUHF;
 
-extern const int RADIO_VHF_MIN;
-extern const int RADIO_VHF_MAX;
-extern const int RADIO_UHF_MIN;
-extern const int RADIO_UHF_MAX;
-
-enum RADIO_MODE { RADIO_MODE_NONE,RADIO_MODE_ANALOG,RADIO_MODE_DIGITAL};
-
-extern bool open_squelch;
-extern bool HR_C6000_datalogging;
-
-extern bool trxIsTransmitting;
-extern uint32_t trxTalkGroup;
-extern uint32_t trxDMRID;
-extern int trx_measure_count;
-
-void trx_check_analog_squelch();
-int	trxGetMode();
-int	trxGetFrequency();
-void trxSetMode(int mode);
-void trxSetFrequency(int frequency);
-void trx_setRX();
-void trx_setTX();
-void trxSetPower(uint32_t powerVal);
-uint16_t trxGetPower();
-
-#endif /* _FW_TRX_H_ */
+#endif

--- a/GD-77_new_firmware/firmware/include/functions/fw_codeplug.h
+++ b/GD-77_new_firmware/firmware/include/functions/fw_codeplug.h
@@ -102,5 +102,5 @@ uint32_t bcd2int(uint32_t in);
 
 void codeplugRxGroupGetDataForIndex(int index, struct_codeplugRxGroup_t *rxGroupBuf);
 void codeplugContactGetDataForIndex(int index, struct_codeplugContact_t *contact);
-
+int codeplugGetUserDMRID();
 #endif

--- a/GD-77_new_firmware/firmware/include/functions/fw_settings.h
+++ b/GD-77_new_firmware/firmware/include/functions/fw_settings.h
@@ -53,6 +53,7 @@ typedef struct settingsStruct
 } settingsStruct_t;
 
 extern settingsStruct_t nonVolatileSettings;
+extern bool settingsIsTgOverride;
 
 void settingsSaveSettings();
 void settingsLoadSettings();

--- a/GD-77_new_firmware/firmware/include/functions/fw_settings.h
+++ b/GD-77_new_firmware/firmware/include/functions/fw_settings.h
@@ -50,6 +50,7 @@ typedef struct settingsStruct
 	uint8_t			initialMenuNumber;
 	int8_t			displayBacklightPercentage;
 	uint8_t			displayInverseVideo;
+	uint16_t		txPower;//
 } settingsStruct_t;
 
 extern settingsStruct_t nonVolatileSettings;

--- a/GD-77_new_firmware/firmware/include/functions/fw_trx.h
+++ b/GD-77_new_firmware/firmware/include/functions/fw_trx.h
@@ -40,6 +40,9 @@ enum RADIO_MODE { RADIO_MODE_NONE,RADIO_MODE_ANALOG,RADIO_MODE_DIGITAL};
 extern bool open_squelch;
 extern bool HR_C6000_datalogging;
 
+extern bool trxIsTransmitting;
+extern uint32_t trxTalkGroup;
+extern uint32_t trxDMRID;
 extern int trx_measure_count;
 
 void trx_check_analog_squelch();

--- a/GD-77_new_firmware/firmware/include/menu/menuUtilityQSOData.h
+++ b/GD-77_new_firmware/firmware/include/menu/menuUtilityQSOData.h
@@ -27,7 +27,7 @@
 #define _MENU_UTILITY_QSO_DATA_H_                    /**< Symbol preventing repeated inclusion */
 #include "fw_common.h"
 
-#define NUM_LASTHEARD_STORED 16
+#define NUM_LASTHEARD_STORED 8
 
 typedef struct dmrIdDataStruct
 {
@@ -41,15 +41,24 @@ typedef struct LinkItem
     struct LinkItem *prev;
     int id;
     int talkGroup;
+    char talkerAlias[32];// 4 blocks of data. 6 bytes + 6 bytes + 7 bytes + 7 bytes . plus 1 for termination some more for safety
     struct LinkItem *next;
 } LinkItem_t;
 
-extern bool menuIsDisplayingQSOData;
+enum QSO_DISPLAY_STATE
+{
+	QSO_DISPLAY_IDLE,
+	QSO_DISPLAY_DEFAULT_SCREEN,
+	QSO_DISPLAY_CALLER_DATA
+};
+
+//extern bool menuIsDisplayingQSOData;
 extern LinkItem_t *LinkHead;
+extern int menuDisplayQSODataState;
 
 bool dmrIDLookup( int targetId,dmrIdDataStruct_t *foundRecord);
 void menuUtilityRenderQSOData();
 void menuUtilityRenderHeader();
 void lastheardInitList();
-void lastHeardListUpdate(int id,int talkGroup);
+void lastHeardListUpdate(uint8_t *dmrDataBuffer);
 #endif

--- a/GD-77_new_firmware/firmware/source/chips/fw_HR-C6000.c
+++ b/GD-77_new_firmware/firmware/source/chips/fw_HR-C6000.c
@@ -412,18 +412,15 @@ void tick_HR_C6000()
 	}
 	taskEXIT_CRITICAL();
 
-	if (((fw_read_buttons() & BUTTON_PTT)!=0) && (slot_state==0))
+	if (trxIsTransmitting==true && (slot_state==0))
 	{
-		// dummy data for now -> we need those value to come from a central place and managed by the menu system
-		uint32_t tmp_tg = 1234;
-		uint32_t tmp_dmrid = 12345678;
 		uint8_t spi_tx[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-		spi_tx[3] = (tmp_tg >> 16) & 0xFF;
-		spi_tx[4] = (tmp_tg >> 8) & 0xFF;
-		spi_tx[5] = (tmp_tg >> 0) & 0xFF;
-		spi_tx[6] = (tmp_dmrid >> 16) & 0xFF;
-		spi_tx[7] = (tmp_dmrid >> 8) & 0xFF;
-		spi_tx[8] = (tmp_dmrid >> 0) & 0xFF;
+		spi_tx[3] = (trxTalkGroup >> 16) & 0xFF;
+		spi_tx[4] = (trxTalkGroup >> 8) & 0xFF;
+		spi_tx[5] = (trxTalkGroup >> 0) & 0xFF;
+		spi_tx[6] = (trxDMRID >> 16) & 0xFF;
+		spi_tx[7] = (trxDMRID >> 8) & 0xFF;
+		spi_tx[8] = (trxDMRID >> 0) & 0xFF;
 		write_SPI_page_reg_bytearray_SPI0(0x02, 0x00, spi_tx, 0x0c);
 		write_SPI_page_reg_byte_SPI0(0x04, 0x40, 0xA3);
 		slot_state=11;
@@ -478,7 +475,7 @@ void tick_HR_C6000()
 			slot_state=12;
 			break;
 		case 12:
-			if (((fw_read_buttons() & BUTTON_PTT)==0) && (tx_sequence==0))
+			if (trxIsTransmitting==false && (tx_sequence==0))
 			{
 				slot_state=14;
 			}
@@ -489,7 +486,7 @@ void tick_HR_C6000()
 			}
 			break;
 		case 13:
-			if (((fw_read_buttons() & BUTTON_PTT)==0) && (tx_sequence==0))
+			if (trxIsTransmitting==false && (tx_sequence==0))
 			{
 				slot_state=14;
 			}

--- a/GD-77_new_firmware/firmware/source/chips/fw_HR-C6000.c
+++ b/GD-77_new_firmware/firmware/source/chips/fw_HR-C6000.c
@@ -339,7 +339,13 @@ void terminate_digital()
 
 void store_qsodata()
 {
+	// If this is the start of a newly received signal, we always need to trigger the display to show this, even if its the same station calling again.
+	if (qsodata_timer==0)
+	{
+		menuDisplayQSODataState = QSO_DISPLAY_CALLER_DATA;
+	}
 	// check if this is a valid data frame, including Talker Alias data frames (0x04 - 0x07)
+	// Not sure if its necessary to check byte [1] for 0x00 but I'm doing this
 	if (tmp_ram[1] == 0x00  && (tmp_ram[0]==0x00 || (tmp_ram[0]>=0x04 && tmp_ram[0]<=0x7)))
 	{
 		lastHeardListUpdate(tmp_ram);

--- a/GD-77_new_firmware/firmware/source/chips/fw_HR-C6000.c
+++ b/GD-77_new_firmware/firmware/source/chips/fw_HR-C6000.c
@@ -537,6 +537,9 @@ void tick_HR_C6000()
 			break;
 		case DMR_STATE_TX_END_2:// 15:
 			write_SPI_page_reg_byte_SPI0(0x04, 0x40, 0xC3);
+
+			init_digital_DMR_RX();
+
 			slot_state = DMR_STATE_IDLE;
 			break;
 		}

--- a/GD-77_new_firmware/firmware/source/functions/fw_calibration.c
+++ b/GD-77_new_firmware/firmware/source/functions/fw_calibration.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C)2019 Kai Ludwig, DG4KLU
+ * Copyright (C)2019 	Roger Clark, VK3KYY / G4KYF
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -24,35 +24,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _FW_TRX_H_
-#define _FW_TRX_H_
+#include "fw_calibration.h"
 
-#include "fw_sound.h"
-#include "fw_i2c.h"
-
-extern const int RADIO_VHF_MIN;
-extern const int RADIO_VHF_MAX;
-extern const int RADIO_UHF_MIN;
-extern const int RADIO_UHF_MAX;
-
-enum RADIO_MODE { RADIO_MODE_NONE,RADIO_MODE_ANALOG,RADIO_MODE_DIGITAL};
-
-extern bool open_squelch;
-extern bool HR_C6000_datalogging;
-
-extern bool trxIsTransmitting;
-extern uint32_t trxTalkGroup;
-extern uint32_t trxDMRID;
-extern int trx_measure_count;
-
-void trx_check_analog_squelch();
-int	trxGetMode();
-int	trxGetFrequency();
-void trxSetMode(int mode);
-void trxSetFrequency(int frequency);
-void trx_setRX();
-void trx_setTX();
-void trxSetPower(uint32_t powerVal);
-uint16_t trxGetPower();
-
-#endif /* _FW_TRX_H_ */
+calibrationStruct_t calibrationVHF;
+calibrationStruct_t calibrationUHF;

--- a/GD-77_new_firmware/firmware/source/functions/fw_codeplug.c
+++ b/GD-77_new_firmware/firmware/source/functions/fw_codeplug.c
@@ -41,6 +41,7 @@ const int CODEPLUG_RX_GROUP_LEN = 0x50;
 const int CODEPLUG_ADDR_CONTACTS = 0x87620;
 const int CODEPLUG_CONTACTS_LEN = 0x18;
 
+const int CODEPLUG_ADDR_USER_DMRID = 0x00E8;
 
 
 uint32_t byteSwap32(uint32_t n)
@@ -61,6 +62,7 @@ uint32_t bcd2int(uint32_t i)
     }
     return result;
 }
+
 
 void codeplugUtilConvertBufToString(char *inBuf,char *outBuf,int len)
 {
@@ -171,5 +173,12 @@ void codeplugContactGetDataForIndex(int index, struct_codeplugContact_t *contact
 {
 	index--;
 	SPI_Flash_read(CODEPLUG_ADDR_CONTACTS + index*sizeof(struct_codeplugContact_t),(uint8_t *)contact,sizeof(struct_codeplugContact_t));
-	contact->tgNumber = bcd2int(contact->tgNumber);
+	contact->tgNumber = bcd2int(byteSwap32(contact->tgNumber));
+}
+
+int codeplugGetUserDMRID()
+{
+	int dmrId;
+	EEPROM_Read(CODEPLUG_ADDR_USER_DMRID,(uint8_t *)&dmrId,4);
+	return bcd2int(byteSwap32(dmrId));
 }

--- a/GD-77_new_firmware/firmware/source/functions/fw_settings.c
+++ b/GD-77_new_firmware/firmware/source/functions/fw_settings.c
@@ -29,6 +29,7 @@
 #include "fw_EEPROM.h"
 #include "fw_trx.h"
 #include "menu/menuSystem.h"
+#include "fw_codeplug.h"
 
 const int BAND_VHF_MIN 	= 1440000;
 const int BAND_VHF_MAX 	= 1480000;
@@ -38,6 +39,7 @@ const int BAND_UHF_MAX 	= 4500000;
 static const int STORAGE_BASE_ADDRESS = 0xFF00;
 static const int STORAGE_MAGIC_NUMBER = 0x4714;
 
+bool settingsIsTgOverride=false;
 settingsStruct_t nonVolatileSettings;
 
 void settingsSaveSettings()
@@ -54,6 +56,7 @@ void settingsLoadSettings()
     	settingsRestoreDefaultSettings();
     	settingsSaveSettings();
 	}
+	trxDMRID = codeplugGetUserDMRID();
 }
 
 void settingsRestoreDefaultSettings()

--- a/GD-77_new_firmware/firmware/source/functions/fw_settings.c
+++ b/GD-77_new_firmware/firmware/source/functions/fw_settings.c
@@ -37,7 +37,7 @@ const int BAND_UHF_MIN 	= 4300000;
 const int BAND_UHF_MAX 	= 4500000;
 
 static const int STORAGE_BASE_ADDRESS = 0xFF00;
-static const int STORAGE_MAGIC_NUMBER = 0x4714;
+static const int STORAGE_MAGIC_NUMBER = 0x4715;
 
 bool settingsIsTgOverride=false;
 settingsStruct_t nonVolatileSettings;
@@ -77,4 +77,5 @@ void settingsRestoreDefaultSettings()
 	nonVolatileSettings.initialMenuNumber=MENU_VFO_MODE;
 	nonVolatileSettings.displayBacklightPercentage=100U;// 100% brightness
 	nonVolatileSettings.displayInverseVideo=0;// Not inverse video
+	nonVolatileSettings.txPower=1000;
 }

--- a/GD-77_new_firmware/firmware/source/functions/fw_trx.c
+++ b/GD-77_new_firmware/firmware/source/functions/fw_trx.c
@@ -31,6 +31,9 @@ bool open_squelch=false;
 bool HR_C6000_datalogging=false;
 
 int trx_measure_count = 0;
+bool trxIsTransmitting = false;
+uint32_t trxTalkGroup=9;// Set to local TG just in case there is some problem with it not being loaded
+uint32_t trxDMRID = 0;// Set ID to 0. Not sure if its valid. This value needs to be loaded from the codeplug.
 
 const int RADIO_VHF_MIN			=	1340000;
 const int RADIO_VHF_MAX			=	1740000;
@@ -41,6 +44,7 @@ static int currentMode = RADIO_MODE_NONE;
 static int currentFrequency =1440000;
 static uint8_t squelch = 0x00;
 static const uint8_t SQUELCH_SETTINGS[] = {45,45,45};
+
 
 int	trxGetMode()
 {
@@ -158,6 +162,7 @@ void trxSetFrequencyAndMode(int frequency,int mode)
 
 void trx_setRX()
 {
+	trxIsTransmitting=false;
 	// MUX for RX
 	trxSetMode(currentMode);
 	GPIO_PinWrite(GPIO_TX_audio_mux, Pin_TX_audio_mux, 0);
@@ -190,6 +195,7 @@ void trx_setRX()
 void trx_setTX()
 {
 	// MUX for TX
+	trxIsTransmitting=true;
 	trxSetMode(currentMode);
 	if (currentMode == RADIO_MODE_ANALOG)
 	{

--- a/GD-77_new_firmware/firmware/source/functions/fw_trx.c
+++ b/GD-77_new_firmware/firmware/source/functions/fw_trx.c
@@ -26,6 +26,7 @@
 
 #include "fw_trx.h"
 #include "fw_HR-C6000.h"
+#include "fw_settings.h"
 
 bool open_squelch=false;
 bool HR_C6000_datalogging=false;
@@ -34,7 +35,6 @@ int trx_measure_count = 0;
 bool trxIsTransmitting = false;
 uint32_t trxTalkGroup=9;// Set to local TG just in case there is some problem with it not being loaded
 uint32_t trxDMRID = 0;// Set ID to 0. Not sure if its valid. This value needs to be loaded from the codeplug.
-
 const int RADIO_VHF_MIN			=	1340000;
 const int RADIO_VHF_MAX			=	1740000;
 const int RADIO_UHF_MIN			=	4000000;
@@ -233,7 +233,20 @@ void trx_setTX()
 		GPIO_PinWrite(GPIO_UHF_TX_amp_power, Pin_UHF_TX_amp_power, 1);
 	}
 
-	// TX Antenna + PA power off
+	// TX Antenna + PA power o
     GPIO_PinWrite(GPIO_RF_ant_switch, Pin_RF_ant_switch, 1);
-    DAC_SetBufferValue(DAC0, 0U, 200U);
+    DAC_SetBufferValue(DAC0, 0U, nonVolatileSettings.txPower);
+}
+
+void trxSetPower(uint32_t powerVal)
+{
+	if (powerVal<4096)
+	{
+		nonVolatileSettings.txPower = powerVal;
+	}
+    DAC_SetBufferValue(DAC0, 0U, nonVolatileSettings.txPower);
+}
+uint16_t trxGetPower()
+{
+	return nonVolatileSettings.txPower;
 }

--- a/GD-77_new_firmware/firmware/source/menu/menuChannelMode.c
+++ b/GD-77_new_firmware/firmware/source/menu/menuChannelMode.c
@@ -77,16 +77,18 @@ static void loadChannelData()
 	codeplugChannelGetDataForIndex(currentZone.channels[nonVolatileSettings.currentChannelIndexInZone],&channelData);
 	trxSetFrequency(bcd2int(channelData.rxFreq)/10);
 	trxSetMode((channelData.chMode==0)?RADIO_MODE_ANALOG:RADIO_MODE_DIGITAL);
+	codeplugRxGroupGetDataForIndex(channelData.rxGroupList,&rxGroupData);
+	codeplugContactGetDataForIndex(rxGroupData.contacts[currentIndexInTRxGroup],&contactData);
+	if (settingsIsTgOverride==false)
+	{
+		trxTalkGroup = contactData.tgNumber;
+	}
 }
 
 
 static void updateScreen()
 {
 	char nameBuf[17];
-
-
-	codeplugRxGroupGetDataForIndex(channelData.rxGroupList,&rxGroupData);
-	codeplugContactGetDataForIndex(rxGroupData.contacts[currentIndexInTRxGroup],&contactData);
 
 	UC1701_clearBuf();
 
@@ -98,7 +100,14 @@ static void updateScreen()
 			codeplugUtilConvertBufToString(channelData.name,nameBuf,16);
 			UC1701_printCentered(20, (char *)nameBuf,UC1701_FONT_GD77_8x16);
 
-			codeplugUtilConvertBufToString(contactData.name,nameBuf,16);
+			if (settingsIsTgOverride)
+			{
+				sprintf(nameBuf,"TG %d",trxTalkGroup);
+			}
+			else
+			{
+				codeplugUtilConvertBufToString(contactData.name,nameBuf,16);
+			}
 			UC1701_printCentered(40, (char *)nameBuf,UC1701_FONT_GD77_8x16);
 			displayLightTrigger();
 			UC1701_render();
@@ -140,6 +149,11 @@ static void handleEvent(int buttons, int keys, int events)
 		{
 			currentIndexInTRxGroup =  0;
 		}
+		codeplugContactGetDataForIndex(rxGroupData.contacts[currentIndexInTRxGroup],&contactData);
+
+		settingsIsTgOverride=false;
+		trxTalkGroup = contactData.tgNumber;
+
 		menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 		updateScreen();
 	}
@@ -151,6 +165,11 @@ static void handleEvent(int buttons, int keys, int events)
 		{
 			currentIndexInTRxGroup =  rxGroupData.NOT_IN_MEMORY_numTGsInGroup - 1;
 		}
+
+		codeplugContactGetDataForIndex(rxGroupData.contacts[currentIndexInTRxGroup],&contactData);
+		settingsIsTgOverride=false;
+		trxTalkGroup = contactData.tgNumber;
+
 		menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 		updateScreen();
 	}

--- a/GD-77_new_firmware/firmware/source/menu/menuChannelMode.c
+++ b/GD-77_new_firmware/firmware/source/menu/menuChannelMode.c
@@ -140,6 +140,8 @@ static void handleEvent(int buttons, int keys, int events)
 		{
 			currentIndexInTRxGroup =  0;
 		}
+		menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
+		updateScreen();
 	}
 	else if ((keys & KEY_LEFT)!=0)
 	{
@@ -149,6 +151,8 @@ static void handleEvent(int buttons, int keys, int events)
 		{
 			currentIndexInTRxGroup =  rxGroupData.NOT_IN_MEMORY_numTGsInGroup - 1;
 		}
+		menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
+		updateScreen();
 	}
 	else if ((keys & KEY_STAR)!=0)
 	{
@@ -160,6 +164,8 @@ static void handleEvent(int buttons, int keys, int events)
 		{
 			trxSetMode(RADIO_MODE_ANALOG);
 		}
+		menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
+		updateScreen();
 	}
 	else if ((keys & KEY_DOWN)!=0)
 	{
@@ -169,6 +175,8 @@ static void handleEvent(int buttons, int keys, int events)
 			nonVolatileSettings.currentChannelIndexInZone =  currentZone.NOT_IN_MEMORY_numChannelsInZone - 1;
 		}
 		loadChannelData();
+		menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
+		updateScreen();
 	}
 	else if ((keys & KEY_UP)!=0)
 	{
@@ -178,31 +186,9 @@ static void handleEvent(int buttons, int keys, int events)
 			nonVolatileSettings.currentChannelIndexInZone = 0;
 		}
 		loadChannelData();
-	}
-	else if ((keys & KEY_1)!=0)
-	{
-		GPIO_PinWrite(GPIO_speaker_mute, Pin_speaker_mute, 0);
-	    GPIO_PinWrite(GPIO_LEDgreen, Pin_LEDgreen, 0);
-		init_digital_DMR_RX();
-		init_digital_state();
-	    NVIC_EnableIRQ(PORTC_IRQn);
-		init_codec();
-	}
-	else if ((keys & KEY_2)!=0)
-	{
-		init_digital_DMR_RX();
-	}
-	else if ((keys & KEY_3)!=0)
-	{
-		init_digital_state();
-	}
-	else if ((keys & KEY_4)!=0)
-	{
-		init_sound();
-	//	init_digital();
+		menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
+		updateScreen();
 	}
 
 
-
-	updateScreen();
 }

--- a/GD-77_new_firmware/firmware/source/menu/menuChannelMode.c
+++ b/GD-77_new_firmware/firmware/source/menu/menuChannelMode.c
@@ -77,6 +77,7 @@ static void loadChannelData()
 	codeplugChannelGetDataForIndex(currentZone.channels[nonVolatileSettings.currentChannelIndexInZone],&channelData);
 	trxSetFrequency(bcd2int(channelData.rxFreq)/10);
 	trxSetMode((channelData.chMode==0)?RADIO_MODE_ANALOG:RADIO_MODE_DIGITAL);
+	trxSetPower(nonVolatileSettings.txPower);
 	codeplugRxGroupGetDataForIndex(channelData.rxGroupList,&rxGroupData);
 	codeplugContactGetDataForIndex(rxGroupData.contacts[currentIndexInTRxGroup],&contactData);
 	if (settingsIsTgOverride==false)

--- a/GD-77_new_firmware/firmware/source/menu/menuChannelMode.c
+++ b/GD-77_new_firmware/firmware/source/menu/menuChannelMode.c
@@ -45,20 +45,19 @@ int menuChannelMode(int buttons, int keys, int events, bool isFirstRun)
 	{
 		nonVolatileSettings.initialMenuNumber = MENU_CHANNEL_MODE;// This menu.
 		codeplugZoneGetDataForIndex(nonVolatileSettings.currentZone,&currentZone);
-		gMenusCurrentItemIndex=0;
+
 		loadChannelData();
+		menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 		updateScreen();
-		menuIsDisplayingQSOData=(qsodata_timer!=0);
 	}
 	else
 	{
 		if (events==0)
 		{
 			// is there an incoming DMR signal
-			if (menuIsDisplayingQSOData != (qsodata_timer!=0))
+			if (menuDisplayQSODataState != QSO_DISPLAY_IDLE)
 			{
 				updateScreen();
-				menuIsDisplayingQSOData=(qsodata_timer!=0);
 			}
 		}
 		else
@@ -93,28 +92,26 @@ static void updateScreen()
 
 	menuUtilityRenderHeader();
 
-	if (qsodata_timer!=0)
+	switch(menuDisplayQSODataState)
 	{
-		menuUtilityRenderQSOData();
+		case QSO_DISPLAY_DEFAULT_SCREEN:
+			codeplugUtilConvertBufToString(channelData.name,nameBuf,16);
+			UC1701_printCentered(20, (char *)nameBuf,UC1701_FONT_GD77_8x16);
+
+			codeplugUtilConvertBufToString(contactData.name,nameBuf,16);
+			UC1701_printCentered(40, (char *)nameBuf,UC1701_FONT_GD77_8x16);
+			displayLightTrigger();
+			UC1701_render();
+			break;
+
+		case QSO_DISPLAY_CALLER_DATA:
+			menuUtilityRenderQSOData();
+			displayLightTrigger();
+			UC1701_render();
+			break;
 	}
-	else
-	{
-/*
- * Not enough room to display the zone as well as channel etc
-		codeplugUtilConvertBufToString(currentZone.name,nameBuf,16);
-		UC1701_printCentered(20, (char *)nameBuf,UC1701_FONT_GD77_8x16);
-*/
 
-		codeplugUtilConvertBufToString(channelData.name,nameBuf,16);
-		UC1701_printCentered(20, (char *)nameBuf,UC1701_FONT_GD77_8x16);
-
-		codeplugUtilConvertBufToString(contactData.name,nameBuf,16);
-		UC1701_printCentered(40, (char *)nameBuf,UC1701_FONT_GD77_8x16);
-
-
-	}
-	displayLightTrigger();
-	UC1701_render();
+	menuDisplayQSODataState = QSO_DISPLAY_IDLE;
 }
 
 static void handleEvent(int buttons, int keys, int events)

--- a/GD-77_new_firmware/firmware/source/menu/menuLastHeard.c
+++ b/GD-77_new_firmware/firmware/source/menu/menuLastHeard.c
@@ -41,7 +41,7 @@ int menuLastHeard(int buttons, int keys, int events, bool isFirstRun)
 	else
 	{
 		// do live update by checking if the item at the top of the list has changed
-		if (gMenusStartIndex != LinkHead->id)
+		if (gMenusStartIndex != LinkHead->id || menuDisplayQSODataState==QSO_DISPLAY_CALLER_DATA)
 		{
 			gMenusStartIndex = LinkHead->id;
 			gMenusCurrentItemIndex=0;
@@ -110,6 +110,7 @@ static void updateScreen()
 
 	UC1701_render();
 	displayLightTrigger();
+	menuDisplayQSODataState = QSO_DISPLAY_IDLE;
 }
 
 

--- a/GD-77_new_firmware/firmware/source/menu/menuLastHeard.c
+++ b/GD-77_new_firmware/firmware/source/menu/menuLastHeard.c
@@ -58,6 +58,7 @@ int menuLastHeard(int buttons, int keys, int events, bool isFirstRun)
 
 static void updateScreen()
 {
+	char buffer[17];
 	dmrIdDataStruct_t foundRecord;
 	int numDisplayed=0;
 	LinkItem_t *item = LinkHead;
@@ -72,11 +73,26 @@ static void updateScreen()
 	}
 	while((item != NULL) && item->id != 0)
 	{
-		dmrIDLookup(item->id,&foundRecord);
+		if (dmrIDLookup(item->id,&foundRecord))
 		{
 			UC1701_printCentered(16+(numDisplayed*16), foundRecord.text,UC1701_FONT_GD77_8x16);
-			numDisplayed++;
 		}
+		else
+		{
+			if (LinkHead->talkerAlias[0] != 0x00)
+			{
+				memcpy(buffer,item->talkerAlias,16);// limit to 1 line of the display which is 16 chars at the normal font size
+				buffer[16]=0x00;
+			}
+			else
+			{
+				sprintf(buffer,"ID:%d",item->id);
+			}
+			UC1701_printCentered(16+(numDisplayed*16), buffer,UC1701_FONT_GD77_8x16);
+		}
+
+		numDisplayed++;
+
 		item=item->next;
 		if (numDisplayed>3)
 		{

--- a/GD-77_new_firmware/firmware/source/menu/menuLastHeard.c
+++ b/GD-77_new_firmware/firmware/source/menu/menuLastHeard.c
@@ -79,7 +79,7 @@ static void updateScreen()
 		}
 		else
 		{
-			if (LinkHead->talkerAlias[0] != 0x00)
+			if (item->talkerAlias[0] != 0x00)
 			{
 				memcpy(buffer,item->talkerAlias,16);// limit to 1 line of the display which is 16 chars at the normal font size
 				buffer[16]=0x00;

--- a/GD-77_new_firmware/firmware/source/menu/menuNumericalEntry.c
+++ b/GD-77_new_firmware/firmware/source/menu/menuNumericalEntry.c
@@ -75,6 +75,12 @@ static void handleEvent(int buttons, int keys, int events)
 		menuSystemPopPreviousMenu();
 		return;
 	}
+	else if ((keys & KEY_GREEN)!=0)
+	{
+		trxTalkGroup = atoi(digits);
+		settingsIsTgOverride=true;
+		menuSystemPopAllAndDisplayRootMenu();
+	}
 	else if ((keys & KEY_HASH)!=0)
 	{
 		gMenusCurrentItemIndex = 1 - gMenusCurrentItemIndex;

--- a/GD-77_new_firmware/firmware/source/menu/menuUtilityQSOData.c
+++ b/GD-77_new_firmware/firmware/source/menu/menuUtilityQSOData.c
@@ -104,7 +104,7 @@ void lastHeardListUpdate(uint8_t *dmrDataBuffer)
 		if (id!=lastID)
 		{
 			lastID=id;
-			menuDisplayQSODataState = QSO_DISPLAY_CALLER_DATA;// flag that the display needs to update
+
 			LinkItem_t *item = findInList(id);
 
 			if (item!=NULL)
@@ -116,7 +116,7 @@ void lastHeardListUpdate(uint8_t *dmrDataBuffer)
 
 				if (item == LinkHead)
 				{
-
+					menuDisplayQSODataState = QSO_DISPLAY_CALLER_DATA;// flag that the display needs to update
 					return;// already at top of the list
 				}
 				else
@@ -141,6 +141,7 @@ void lastHeardListUpdate(uint8_t *dmrDataBuffer)
 
 					item->prev=NULL;// change the items prev to NULL now we are at teh top of the list
 					LinkHead = item;// Change the global for the head of the link to the item that is to be at the top of the list.
+					menuDisplayQSODataState = QSO_DISPLAY_CALLER_DATA;// flag that the display needs to update
 				}
 			}
 			else
@@ -165,6 +166,7 @@ void lastHeardListUpdate(uint8_t *dmrDataBuffer)
 				item->id=id;
 				item->talkGroup =  talkGroup;
 				memset(item->talkerAlias,0,32);// Clear any TA data
+				menuDisplayQSODataState = QSO_DISPLAY_CALLER_DATA;// flag that the display needs to update
 			}
 		}
 	}

--- a/GD-77_new_firmware/firmware/source/menu/menuVFOMode.c
+++ b/GD-77_new_firmware/firmware/source/menu/menuVFOMode.c
@@ -80,21 +80,17 @@ int menuVFOMode(int buttons, int keys, int events, bool isFirstRun)
 
 static void updateScreen()
 {
+	char buffer[32];
 	UC1701_clearBuf();
 	menuUtilityRenderHeader();
 
 	switch(menuDisplayQSODataState)
 	{
 		case QSO_DISPLAY_DEFAULT_SCREEN:
-			if (trxGetMode() == RADIO_MODE_ANALOG)
-			{
-				UC1701_printCentered(20, "Analog",UC1701_FONT_GD77_8x16);
-			}
-			else if (trxGetMode() == RADIO_MODE_DIGITAL)
-			{
-				UC1701_printCentered(20, "DMR",UC1701_FONT_GD77_8x16);
-			}
-			char buffer[32];
+			sprintf(buffer,"TG %d",trxTalkGroup);
+
+			UC1701_printCentered(20,buffer,UC1701_FONT_GD77_8x16);
+
 			if (freq_enter_idx==0)
 			{
 				int val_before_dp = nonVolatileSettings.vfoFrequenciesArray[nonVolatileSettings.currentVFOIndex]/10000;

--- a/GD-77_new_firmware/firmware/source/menu/menuVFOMode.c
+++ b/GD-77_new_firmware/firmware/source/menu/menuVFOMode.c
@@ -54,6 +54,7 @@ int menuVFOMode(int buttons, int keys, int events, bool isFirstRun)
 		nonVolatileSettings.initialMenuNumber=MENU_VFO_MODE;
 		trxSetFrequency(nonVolatileSettings.vfoFrequenciesArray[nonVolatileSettings.currentVFOIndex]);
 		trxSetMode(nonVolatileSettings.vfoTrxMode);
+		trxSetPower(nonVolatileSettings.txPower);
 		reset_freq_enter_digits();
 		menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 		updateScreen();

--- a/GD-77_new_firmware/firmware/source/menu/menuVFOMode.c
+++ b/GD-77_new_firmware/firmware/source/menu/menuVFOMode.c
@@ -43,17 +43,19 @@ static void reset_freq_enter_digits();
 static int read_freq_enter_digits();
 static bool check_frequency(int tmp_frequency);
 static void update_frequency(int tmp_frequency);
-
+bool menuIsDisplayingQSOData = false;// HACK ALERT. DO NOT DELETE THIS LINE. BECAUSE THE DMR AUDIO WILL STOP WOKRING
 
 // public interface
 int menuVFOMode(int buttons, int keys, int events, bool isFirstRun)
 {
+	menuIsDisplayingQSOData=true;// HACK ALERT. DO NOT DELETE THIS LINE. BECAUSE THE DMR AUDIO WILL STOP WOKRING
 	if (isFirstRun)
 	{
 		nonVolatileSettings.initialMenuNumber=MENU_VFO_MODE;
 		trxSetFrequency(nonVolatileSettings.vfoFrequenciesArray[nonVolatileSettings.currentVFOIndex]);
 		trxSetMode(nonVolatileSettings.vfoTrxMode);
 		reset_freq_enter_digits();
+		menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 		updateScreen();
 	}
 	else
@@ -61,10 +63,9 @@ int menuVFOMode(int buttons, int keys, int events, bool isFirstRun)
 		if (events==0)
 		{
 			// is there an incoming DMR signal
-			if (menuIsDisplayingQSOData != (qsodata_timer!=0))
+			if (menuDisplayQSODataState != QSO_DISPLAY_IDLE)
 			{
 				updateScreen();
-				menuIsDisplayingQSOData=(qsodata_timer!=0);
 			}
 		}
 		else
@@ -72,6 +73,7 @@ int menuVFOMode(int buttons, int keys, int events, bool isFirstRun)
 			handleEvent(buttons, keys, events);
 		}
 	}
+
 	return 0;
 }
 
@@ -81,37 +83,40 @@ static void updateScreen()
 	UC1701_clearBuf();
 	menuUtilityRenderHeader();
 
-	if (qsodata_timer!=0)
+	switch(menuDisplayQSODataState)
 	{
-		menuUtilityRenderQSOData();
-		displayLightOverrideTimeout(-1);// turn the display light on without timeout
-	}
-	else
-	{
-		if (trxGetMode() == RADIO_MODE_ANALOG)
-		{
-			UC1701_printCentered(20, "Analog",UC1701_FONT_GD77_8x16);
-		}
-		else if (trxGetMode() == RADIO_MODE_DIGITAL)
-		{
-			UC1701_printCentered(20, "DMR",UC1701_FONT_GD77_8x16);
-		}
-		char buffer[32];
-		if (freq_enter_idx==0)
-		{
-			int val_before_dp = nonVolatileSettings.vfoFrequenciesArray[nonVolatileSettings.currentVFOIndex]/10000;
-			int val_after_dp = nonVolatileSettings.vfoFrequenciesArray[nonVolatileSettings.currentVFOIndex] - val_before_dp*10000;
-			sprintf(buffer,"#%d %d.%04d MHz", nonVolatileSettings.currentVFOIndex+1, val_before_dp, val_after_dp);
-		}
-		else
-		{
-			sprintf(buffer,"#%d %c%c%c.%c%c%c%c MHz", nonVolatileSettings.currentVFOIndex+1, freq_enter_digits[0], freq_enter_digits[1], freq_enter_digits[2], freq_enter_digits[3], freq_enter_digits[4], freq_enter_digits[5], freq_enter_digits[6] );
-		}
-		UC1701_printCentered(40, buffer,UC1701_FONT_GD77_8x16);
-		displayLightTrigger();
-	}
+		case QSO_DISPLAY_DEFAULT_SCREEN:
+			if (trxGetMode() == RADIO_MODE_ANALOG)
+			{
+				UC1701_printCentered(20, "Analog",UC1701_FONT_GD77_8x16);
+			}
+			else if (trxGetMode() == RADIO_MODE_DIGITAL)
+			{
+				UC1701_printCentered(20, "DMR",UC1701_FONT_GD77_8x16);
+			}
+			char buffer[32];
+			if (freq_enter_idx==0)
+			{
+				int val_before_dp = nonVolatileSettings.vfoFrequenciesArray[nonVolatileSettings.currentVFOIndex]/10000;
+				int val_after_dp = nonVolatileSettings.vfoFrequenciesArray[nonVolatileSettings.currentVFOIndex] - val_before_dp*10000;
+				sprintf(buffer,"#%d %d.%04d MHz", nonVolatileSettings.currentVFOIndex+1, val_before_dp, val_after_dp);
+			}
+			else
+			{
+				sprintf(buffer,"#%d %c%c%c.%c%c%c%c MHz", nonVolatileSettings.currentVFOIndex+1, freq_enter_digits[0], freq_enter_digits[1], freq_enter_digits[2], freq_enter_digits[3], freq_enter_digits[4], freq_enter_digits[5], freq_enter_digits[6] );
+			}
+			UC1701_printCentered(40, buffer,UC1701_FONT_GD77_8x16);
+			displayLightTrigger();
+			UC1701_render();
+			break;
 
-	UC1701_render();
+		case QSO_DISPLAY_CALLER_DATA:
+			menuUtilityRenderQSOData();
+			displayLightTrigger();
+			UC1701_render();
+			break;
+	}
+	menuDisplayQSODataState = QSO_DISPLAY_IDLE;
 }
 
 
@@ -181,6 +186,7 @@ static void handleEvent(int buttons, int keys, int events)
 				nonVolatileSettings.currentVFOIndex=0;
 			}
 			trxSetFrequency(nonVolatileSettings.vfoFrequenciesArray[nonVolatileSettings.currentVFOIndex]);
+			menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 		}
 		else if ((keys & KEY_LEFT)!=0)
 		{
@@ -190,6 +196,7 @@ static void handleEvent(int buttons, int keys, int events)
 				nonVolatileSettings.currentVFOIndex=VFO_COUNT-1;
 			}
 			trxSetFrequency(nonVolatileSettings.vfoFrequenciesArray[nonVolatileSettings.currentVFOIndex]);
+			menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 		}
 		else if ((keys & KEY_STAR)!=0)
 		{
@@ -202,6 +209,7 @@ static void handleEvent(int buttons, int keys, int events)
 				trxSetMode(RADIO_MODE_ANALOG);
 			}
 			nonVolatileSettings.vfoTrxMode=trxGetMode();
+			menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 		}
 		else if ((keys & KEY_DOWN)!=0)
 		{
@@ -214,6 +222,7 @@ static void handleEvent(int buttons, int keys, int events)
 			{
         	    set_melody(melody_ERROR_beep);
 			}
+			menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 		}
 		else if ((keys & KEY_UP)!=0)
 		{
@@ -226,6 +235,7 @@ static void handleEvent(int buttons, int keys, int events)
 			{
         	    set_melody(melody_ERROR_beep);
 			}
+			menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 		}
 		else if ((keys & KEY_RED)!=0)
 		{
@@ -239,11 +249,13 @@ static void handleEvent(int buttons, int keys, int events)
 		{
 			freq_enter_idx--;
 			freq_enter_digits[freq_enter_idx]='-';
+			menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 		}
 		else if ((keys & KEY_RED)!=0)
 		{
 			reset_freq_enter_digits();
     	    set_melody(melody_NACK_beep);
+    		menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 		}
 	}
 	if (freq_enter_idx<7)
@@ -307,6 +319,7 @@ static void handleEvent(int buttons, int keys, int events)
 	        	    set_melody(melody_ERROR_beep);
 				}
 			}
+			menuDisplayQSODataState = QSO_DISPLAY_DEFAULT_SCREEN;
 		}
 
 	}


### PR DESCRIPTION
This PR adds Talker Alias support.

It also changes the way that the caller information is handled, so that the LastHeard array of structs is used by the menuChannel and menuVFO screen as well as the LastHeard screen.

The channel and VFO screens simply use the ID of the station at the top of the LastHeard list, as this should be the station which is currently transmitting.
